### PR TITLE
Fix cmake link errors

### DIFF
--- a/Library/CMakeLists.txt
+++ b/Library/CMakeLists.txt
@@ -26,6 +26,7 @@ set(H2LIB_SRCS
    laplacebem3d.c
    macrosurface3d.c
    parameters.c
+   realavector.c
    rkmatrix.c
    settings.c
    singquad1d.c
@@ -64,6 +65,7 @@ set(H2LIB_HDRS
    laplacebem3d.h
    macrosurface3d.h
    parameters.h
+   realavector.h
    rkmatrix.h
    settings.h
    singquad1d.h

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(${PROJECT_SOURCE_DIR}/Library)
 foreach(t ${TESTS})
   set(test_executable test_${t})
   add_executable(${test_executable} ${test_executable}.c)
-  target_link_libraries(${test_executable} H2LIB ${gcov})
+  target_link_libraries(${test_executable} H2LIB ${gcov} -lm)
   add_test(${t} ${test_executable})
 endforeach()
 


### PR DESCRIPTION
Building the tests with cmake fails for me because of a missing '-lm' and because realavector.c is not included in the library. This request fixes both errors.