### PR TITLE
Fix INLINE_PREFIX for C++

### DIFF
--- a/Library/settings.h
+++ b/Library/settings.h
@@ -26,7 +26,7 @@
 
 /** @brief Prefix for inline functions. */
 #ifdef __cplusplus
-#define INLINE_PREFIX static extern "C"
+#define INLINE_PREFIX extern "C" inline
 #else
 #define INLINE_PREFIX static
 #endif


### PR DESCRIPTION
You can't have `static extern "C"` in C++.
It seems that `extren "C" inline is what you want.