### PR TITLE
Use stdbool.h instead of defining bool

### DIFF
--- a/Library/settings.c
+++ b/Library/settings.c
@@ -5,9 +5,6 @@
 
 #include "settings.h"
 
-const bool true = 1;
-const bool false = 0;
-
 #ifdef USE_FLOAT
 const real r_zero = 0.0f;
 const real r_one = 1.0f;

--- a/Library/settings.h
+++ b/Library/settings.h
@@ -49,14 +49,7 @@
  * Types
  * ------------------------------------------------------------ */
 
-/** @brief Boolean type. */
-typedef unsigned short bool;
-
-/** @brief Boolean constant <tt>true</tt>. */
-extern const bool true;
-
-/** @brief Boolean constant <tt>false</tt>. */
-extern const bool false;
+#include<stdbool.h>
 
 /** @brief Unsigned integer type.
  *


### PR DESCRIPTION
This allows to include the header with C++. If the
C++ type bool and the C99 type _Bool are compatible
for your compiler, this will even link.