### PR TITLE
Community

### DIFF
--- a/Library/bem3d.c
+++ b/Library/bem3d.c
@@ -3039,32 +3039,17 @@ assemble_ll_near_bem3d(const uint * ridx, const uint * cidx, pcbem3d bem,
 		       bool ntrans, pamatrix N, kernel_func3d kernel)
 {
   const pcsurface3d gr = bem->gr;
-  const     real(*gr_x)[3] = (const real(*)[3]) gr->x;
-  const     uint(*gr_t)[3] = (const uint(*)[3]) gr->t;
-  const     real(*gr_n)[3] = (const real(*)[3]) gr->n;
-  const preal gr_g = (const preal) gr->g;
   const uint triangles = gr->triangles;
   plistnode *v2t = bem->v2t;
-  field    *quad;
   field    *aa = N->a;
   uint      rows = ntrans ? N->cols : N->rows;
   uint      cols = ntrans ? N->rows : N->cols;
   longindex ld = N->ld;
 
-  ptri_list tl_r, tl1_r, tl_c, tl1_c;
-  pvert_list vl_r, vl_c;
-  const real *A_t, *B_t, *C_t, *A_s, *B_s, *C_s, *nt, *ns;
-  const uint *tri_t, *tri_s;
+    ptri_list tl_r, tl1_r, tl_c, tl1_c;
   plistnode v;
-  real     *xq, *yq, *wq, *ww;
-  uint      tp[3], sp[3], tri_tp[3], tri_sp[3];
-  real      Ax, Bx, Cx, Ay, By, Cy, tx, sx, ty, sy, x[3], y[3], factor,
-    factor2, base;
-  field     res;
-  real     *mass;
-  uint      i, j, t, s, k, l, rj, cj, tt, ss, q, nq, vnq, ii, jj, vv;
-
-  quad = allocfield(bem->sq->nmax);
+  uint      i, j, s, rj, cj, ii, vv;
+  field    *quad;
 
   clear_amatrix(N);
 
@@ -3115,138 +3100,191 @@ assemble_ll_near_bem3d(const uint * ridx, const uint * cidx, pcbem3d bem,
     }
   }
 
+#ifdef USE_OPENMP
+field **current_thread_quad;
+#pragma omp parallel if(!omp_in_parallel()) num_threads(1 << max_pardepth) shared(current_thread_quad)
+  {
+#pragma omp single
+  {
+      current_thread_quad = (field **) malloc(omp_get_num_threads() * sizeof(field *));
+      for (i = 0; i < omp_get_num_threads(); ++i)
+          current_thread_quad[i] = allocfield(bem->sq->nmax);
+
   for (s = 0, tl1_c = tl_c; s < cj; s++, tl1_c = tl1_c->next) {
-    ss = tl1_c->t;
-    assert(ss < triangles);
-    factor = gr_g[ss] * bem->kernel_const;
-    tri_s = gr_t[ss];
-    ns = gr_n[ss];
-    for (t = 0, tl1_r = tl_r; t < rj; t++, tl1_r = tl1_r->next) {
-      tt = tl1_r->t;
-      assert(tt < triangles);
-      factor2 = factor * gr_g[tt];
-      tri_t = gr_t[tt];
-      nt = gr_n[tt];
 
-      select_quadrature_singquad2d(bem->sq, tri_t, tri_s, tp, sp, &xq, &yq,
-				   &wq, &nq, &base);
-      vnq = ROUNDUP(nq, VREAL);
+#pragma omp task default(shared)  private(i, j, ii, quad) firstprivate(tl_r, tl1_r, tl_c, tl1_c)
+{
+    quad = current_thread_quad[omp_get_thread_num()];
+#else
+    quad = allocfield(bem->sq->nmax);;
+    for (s = 0, tl1_c = tl_c; s < cj; s++, tl1_c = tl1_c->next) {
+#endif
+        const real(*gr_x)[3] = (const real(*)[3]) gr->x;
+        const uint(*gr_t)[3] = (const uint(*)[3]) gr->t;
+        const real(*gr_n)[3] = (const real(*)[3]) gr->n;
+        const preal gr_g = (const preal) gr->g;
 
-      for (i = 0; i < 3; ++i) {
-	tri_tp[i] = tri_t[tp[i]];
-	tri_sp[i] = tri_s[sp[i]];
-      }
+        uint t, k, l, tt, ss, q, nq, vnq, jj;
+        const real *A_t, *B_t, *C_t, *A_s, *B_s, *C_s, *nt, *ns;
+        pvert_list vl_r, vl_c;
+        const uint *tri_t, *tri_s;
+        real *xq, *yq, *wq, *ww;
+        uint tp[3], sp[3], tri_tp[3], tri_sp[3];
+        real Ax, Bx, Cx, Ay, By, Cy, tx, sx, ty, sy, x[3], y[3], factor,
+                factor2, base;
+        field res;
+        real *mass;
 
-      A_t = gr_x[tri_tp[0]];
-      B_t = gr_x[tri_tp[1]];
-      C_t = gr_x[tri_tp[2]];
-      A_s = gr_x[tri_sp[0]];
-      B_s = gr_x[tri_sp[1]];
-      C_s = gr_x[tri_sp[2]];
+        ss = tl1_c->t;
+        assert(ss < triangles);
+        factor = gr_g[ss] * bem->kernel_const;
+        tri_s = gr_t[ss];
+        ns = gr_n[ss];
 
-      for (q = 0; q < nq; ++q) {
-	tx = xq[q];
-	sx = xq[q + vnq];
-	ty = yq[q];
-	sy = yq[q + vnq];
-	Ax = 1.0 - tx;
-	Bx = tx - sx;
-	Cx = sx;
-	Ay = 1.0 - ty;
-	By = ty - sy;
-	Cy = sy;
+        for (t = 0, tl1_r = tl_r; t < rj && tl1_r != NULL; t++, tl1_r = tl1_r->next) {
+            tt = tl1_r->t;
+            assert(tt < triangles);
+            factor2 = factor * gr_g[tt];
+            tri_t = gr_t[tt];
+            nt = gr_n[tt];
 
-	x[0] = A_t[0] * Ax + B_t[0] * Bx + C_t[0] * Cx;
-	x[1] = A_t[1] * Ax + B_t[1] * Bx + C_t[1] * Cx;
-	x[2] = A_t[2] * Ax + B_t[2] * Bx + C_t[2] * Cx;
-	y[0] = A_s[0] * Ay + B_s[0] * By + C_s[0] * Cy;
-	y[1] = A_s[1] * Ay + B_s[1] * By + C_s[1] * Cy;
-	y[2] = A_s[2] * Ay + B_s[2] * By + C_s[2] * Cy;
+            select_quadrature_singquad2d(bem->sq, tri_t, tri_s, tp, sp, &xq, &yq,
+                                         &wq, &nq, &base);
+            vnq = ROUNDUP(nq, VREAL);
 
-	quad[q] = kernel(x, y, nt, ns, (void *) bem);
-      }
+            for (i = 0; i < 3; ++i) {
+                tri_tp[i] = tri_t[tp[i]];
+                tri_sp[i] = tri_s[sp[i]];
+            }
 
-      vl_c = tl1_c->vl;
-      while (vl_c) {
-	j = vl_c->v;
-	assert(j < cols);
-	jj = ((cidx == NULL) ? j : cidx[j]);
-	for (k = 0; k < 3; ++k) {
-	  if (jj == tri_sp[k]) {
-	    vl_r = tl1_r->vl;
-	    while (vl_r) {
-	      i = vl_r->v;
-	      assert(i < rows);
-	      ii = ((ridx == NULL) ? i : ridx[i]);
-	      for (l = 0; l < 3; ++l) {
-		if (ii == tri_tp[l]) {
-		  res = base;
+            A_t = gr_x[tri_tp[0]];
+            B_t = gr_x[tri_tp[1]];
+            C_t = gr_x[tri_tp[2]];
+            A_s = gr_x[tri_sp[0]];
+            B_s = gr_x[tri_sp[1]];
+            C_s = gr_x[tri_sp[2]];
 
-		  ww = wq + (l + k * 3) * vnq;
-		  for (q = 0; q < nq; ++q) {
-		    res += ww[q] * quad[q];
-		  }
+            for (q = 0; q < nq; ++q) {
+                tx = xq[q];
+                sx = xq[q + vnq];
+                ty = yq[q];
+                sy = yq[q + vnq];
+                Ax = 1.0 - tx;
+                Bx = tx - sx;
+                Cx = sx;
+                Ay = 1.0 - ty;
+                By = ty - sy;
+                Cy = sy;
 
-		  if (ntrans) {
-		    aa[j + i * ld] += CONJ(res * factor2);
-		  }
-		  else {
-		    aa[i + j * ld] += res * factor2;
-		  }
-		}
-	      }
-	      vl_r = vl_r->next;
-	    }
-	  }
-	}
-	vl_c = vl_c->next;
-      }
+                x[0] = A_t[0] * Ax + B_t[0] * Bx + C_t[0] * Cx;
+                x[1] = A_t[1] * Ax + B_t[1] * Bx + C_t[1] * Cx;
+                x[2] = A_t[2] * Ax + B_t[2] * Bx + C_t[2] * Cx;
+                y[0] = A_s[0] * Ay + B_s[0] * By + C_s[0] * Cy;
+                y[1] = A_s[1] * Ay + B_s[1] * By + C_s[1] * Cy;
+                y[2] = A_s[2] * Ay + B_s[2] * By + C_s[2] * Cy;
 
-      if (bem->alpha != 0.0 && tt == ss) {
-	for (i = 0; i < 3; ++i) {
-	  tri_tp[i] = tri_t[i];
-	  tri_sp[i] = tri_s[i];
-	}
+                quad[q] = kernel(x, y, nt, ns, (void *) bem);
+            }
 
-	mass = bem->mass;
-	factor2 = bem->alpha * gr_g[tt];
+            vl_c = tl1_c->vl;
+            while (vl_c) {
+                j = vl_c->v;
+                assert(j < cols);
+                jj = ((cidx == NULL) ? j : cidx[j]);
+                for (k = 0; k < 3; ++k) {
+                    if (jj == tri_sp[k]) {
+                        vl_r = tl1_r->vl;
+                        while (vl_r) {
+                            i = vl_r->v;
+                            assert(i < rows);
+                            ii = ((ridx == NULL) ? i : ridx[i]);
+                            for (l = 0; l < 3; ++l) {
+                                if (ii == tri_tp[l]) {
+                                    res = base;
 
-	vl_c = tl1_c->vl;
-	while (vl_c) {
-	  j = vl_c->v;
-	  assert(j < cols);
-	  jj = ((cidx == NULL) ? j : cidx[j]);
-	  for (k = 0; k < 3; ++k) {
-	    if (jj == tri_sp[k]) {
-	      vl_r = tl1_r->vl;
-	      while (vl_r) {
-		i = vl_r->v;
-		assert(i < rows);
-		ii = ((ridx == NULL) ? i : ridx[i]);
-		for (l = 0; l < 3; ++l) {
-		  if (ii == tri_tp[l]) {
-		    if (ntrans) {
-		      aa[j + i * ld] += CONJ(mass[l + k * 3] * factor2);
-		    }
-		    else {
-		      aa[i + j * ld] += mass[l + k * 3] * factor2;
-		    }
-		  }
-		}
-		vl_r = vl_r->next;
-	      }
-	    }
-	  }
-	  vl_c = vl_c->next;
-	}
+                                    ww = wq + (l + k * 3) * vnq;
+                                    for (q = 0; q < nq; ++q) {
+                                        res += ww[q] * quad[q];
+                                    }
+
+                                    if (ntrans) {
+                                    #ifdef USE_OPENMP
+                                        #pragma omp atomic
+                                    #endif
+                                        aa[j + i * ld] += CONJ(res * factor2);
+                                    } else {
+                                    #ifdef USE_OPENMP
+                                        #pragma omp atomic
+                                    #endif
+                                        aa[i + j * ld] += res * factor2;
+                                    }
+                                }
+                            }
+                            vl_r = vl_r->next;
+                        }
+                    }
+                }
+                vl_c = vl_c->next;
+            }
+            if (bem->alpha != 0.0 && tt == ss) {
+                for (i = 0; i < 3; ++i) {
+                    tri_tp[i] = tri_t[i];
+                    tri_sp[i] = tri_s[i];
+                }
+
+                mass = bem->mass;
+                factor2 = bem->alpha * gr_g[tt];
+
+                vl_c = tl1_c->vl;
+                while (vl_c) {
+                    j = vl_c->v;
+                    assert(j < cols);
+                    jj = ((cidx == NULL) ? j : cidx[j]);
+                    for (k = 0; k < 3; ++k) {
+                        if (jj == tri_sp[k]) {
+                            vl_r = tl1_r->vl;
+                            while (vl_r) {
+                                i = vl_r->v;
+                                assert(i < rows);
+                                ii = ((ridx == NULL) ? i : ridx[i]);
+                                for (l = 0; l < 3; ++l) {
+                                    if (ii == tri_tp[l]) {
+                                        if (ntrans) {
+                                        #ifdef USE_OPENMP
+                                            #pragma omp atomic
+                                        #endif
+                                            aa[j + i * ld] += CONJ(mass[l + k * 3] * factor2);
+                                        } else {
+                                        #ifdef USE_OPENMP
+                                            #pragma omp atomic
+                                        #endif
+                                            aa[i + j * ld] += mass[l + k * 3] * factor2;
+                                        }
+                                    }
+                                }
+                                vl_r = vl_r->next;
+                            }
+                        }
+                    }
+                    vl_c = vl_c->next;
+                }
+            }
+        }
+#ifdef USE_OPENMP
+        }
       }
     }
   }
-
+  for (i = 0; i < omp_get_num_threads(); ++i)
+      freemem(current_thread_quad[i]);
+  free(current_thread_quad);
+  current_thread_quad = NULL;
+#else
+    }
+    freemem(quad);
+#endif
   del_tri_list(tl_r);
   del_tri_list(tl_c);
-
-  freemem(quad);
 }
 
 #ifdef USE_SIMD

--- a/Library/bem3d.c
+++ b/Library/bem3d.c
@@ -3039,6 +3039,10 @@ assemble_ll_near_bem3d(const uint * ridx, const uint * cidx, pcbem3d bem,
 		       bool ntrans, pamatrix N, kernel_func3d kernel)
 {
   const pcsurface3d gr = bem->gr;
+  const real(*gr_x)[3] = (const real(*)[3]) gr->x;
+  const uint(*gr_t)[3] = (const uint(*)[3]) gr->t;
+  const real(*gr_n)[3] = (const real(*)[3]) gr->n;
+  const preal gr_g = (const preal) gr->g;
   const uint triangles = gr->triangles;
   plistnode *v2t = bem->v2t;
   field    *aa = N->a;
@@ -3119,11 +3123,6 @@ field **current_thread_quad;
     quad = allocfield(bem->sq->nmax);;
     for (s = 0, tl1_c = tl_c; s < cj; s++, tl1_c = tl1_c->next) {
 #endif
-        const real(*gr_x)[3] = (const real(*)[3]) gr->x;
-        const uint(*gr_t)[3] = (const uint(*)[3]) gr->t;
-        const real(*gr_n)[3] = (const real(*)[3]) gr->n;
-        const preal gr_g = (const preal) gr->g;
-
         uint t, k, l, tt, ss, q, nq, vnq, jj;
         const real *A_t, *B_t, *C_t, *A_s, *B_s, *C_s, *nt, *ns;
         pvert_list vl_r, vl_c;

--- a/Makefile
+++ b/Makefile
@@ -200,12 +200,14 @@ Library/helmholtzoclbem3d.c: Library/helmholtzbem3d.cl
 # Build configuration
 # ------------------------------------------------------------
 
+ifndef IGNORE_DEFAULT_READING
 ifeq ($(wildcard options.inc),)
 $(OBJECTS): options.inc.default
 include options.inc.default
 else
 $(OBJECTS): options.inc
 include options.inc
+endif
 endif
 
 # ------------------------------------------------------------


### PR DESCRIPTION
Hello, hope you are doing well!

The first commit adds OpenMP parallelization to the bem3d assembly function.

The second adds the option of ignoring the input from the options.inc.default file in the build process. This is interesting because if you are doing automated builds, the ideal is for the lib to be built directly after cloned, not needing to pull other custom configuration files from different sources or using forks. Now, if you use the default file and want to remove some of the preset options you need to make the script comment or delete some of the lines, which is cumbersome and not a really generic approach. The addition of this option allows specific variables to be set or unset in the environment to be latter on used by make. This keeps current scripts interoperable with future configuration files and still keeps the default reading behavior the same.

I would also like to suggest a brief comment on the master branch README to indicate that contributions should be made on the community branch.

Thanks in advance and have a nice day!